### PR TITLE
Revive `cudd-sys`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,80 @@
+name: build
+on: [push]
+env:
+  # A fixed version used for testing, so that the builds don't
+  # spontaneously break after a few years.
+  RUST_VERSION: "1.53.0"
+jobs:
+  # Checks syntax formatting.
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_VERSION }}
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  # Run basic code validity check.
+  check:
+    needs: fmt
+    name: Check
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_VERSION }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  # Run tests.
+  test:
+    needs: check
+    name: Test Suite
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_VERSION }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  # Checks code style.
+  clippy:
+    needs: check
+    name: Clippy
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_VERSION }}
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,26 @@ jobs:
   # Run tests.
   test:
     needs: check
-    name: Test Suite
+    name: Test Suite (linux)
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_VERSION }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  # Run tests on macOS.
+  test-macos:
+    needs: check
+    name: Test Suite (macOS)
+    runs-on: macos-latest
     env:
       RUSTFLAGS: "-D warnings"
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target
 Cargo.lock
 .#*
+
+.idea
+.DS_store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: rust

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+[![Crates.io](https://img.shields.io/crates/v/cudd-sys?style=flat-square)](https://crates.io/crates/cudd-sys)
+[![Api Docs](https://img.shields.io/badge/docs-api-yellowgreen?style=flat-square)](https://docs.rs/cudd-sys/)
+[![Continuous integration](https://img.shields.io/github/workflow/status/pclewis/cudd-sys/build?style=flat-square)](https://github.com/pclewis/cudd-sys/actions?query=workflow%3Abuild)
+
+# Rust Bindings for the CUDD library
+
+Allows usage of the CUDD decision diagram library from Rust (tested on Linux and macOS). Uses version `2.5.1` of CUDD available from the unofficial [Github mirror](https://github.com/ivmai/cudd). 
+
+To learn more about CUDD, check out the [manual](https://add-lib.scce.info/assets/documents/cudd-manual.pdf) or [API documentation](https://add-lib.scce.info/assets/doxygen-cudd-documentation/cudd_8h.html).

--- a/build.rs
+++ b/build.rs
@@ -6,8 +6,8 @@ use std::io::{BufReader,BufWriter,BufRead,Write};
 use std::fs::File;
 use std::path::{Path,PathBuf};
 
-const PACKAGE_URL:&'static str = "https://github.com/ivmai/cudd/archive/refs/tags/cudd-2.5.1.tar.gz";
-const PACKAGE_MD5:&'static str = "42283a52ff815c5ca8231b6927318fbf";
+const PACKAGE_URL: &str = "https://github.com/ivmai/cudd/archive/refs/tags/cudd-2.5.1.tar.gz";
+const PACKAGE_MD5: &str = "42283a52ff815c5ca8231b6927318fbf";
 
 #[derive(Debug)]
 enum FetchError {
@@ -24,7 +24,7 @@ enum MD5Status {
 
 impl From<std::io::Error> for FetchError {
     fn from(err: std::io::Error) -> FetchError {
-        return FetchError::IOError( err );
+        FetchError::IOError( err )
     }
 }
 
@@ -67,11 +67,11 @@ fn fetch_package(out_dir: &str, url: &str, md5: &str) -> Result<(PathBuf, MD5Sta
             }
         }
 
-        run_command( &mut Command::new("md5sum").arg(target_path_str) ).or(
+        run_command( &mut Command::new("md5sum").arg(target_path_str) ).or_else(|_|
             run_command( &mut Command::new("md5").arg(target_path_str) ))
     };
 
-    return Ok(
+    Ok(
         (target_path,
         match md5_result {
             Err( _ ) => MD5Status::Unknown,
@@ -80,7 +80,7 @@ fn fetch_package(out_dir: &str, url: &str, md5: &str) -> Result<(PathBuf, MD5Sta
                 if out.contains(md5) { MD5Status::Match }
                 else { MD5Status::Mismatch }
             }
-        }));
+        }))
 
 }
 
@@ -111,7 +111,7 @@ fn replace_lines( path: &Path, replacements: Vec<(&str,&str)> ) -> Result< u32, 
     fs::remove_file(&path)?;
     fs::rename(&new_path, &path)?;
 
-    return Ok( lines_replaced );
+    Ok( lines_replaced )
 }
 
 fn main() {
@@ -137,12 +137,12 @@ fn main() {
     // patch Makefile
     let lines_replaced = replace_lines(
         &untarred_path.join("Makefile"),
-        vec!(// need PIC so our rust lib can be dynamically linked
+        vec![// need PIC so our rust lib can be dynamically linked
             ("ICFLAGS\t= -g -O3",
              "ICFLAGS\t= -g -O3 -fPIC"),
             // remove "nanotrav" from DIRS, it doesn't compile on OSX
             ("DIRS\t= $(BDIRS)", // (matches prefix)
-             "DIRS\t= $(BDIRS)"))).unwrap();
+             "DIRS\t= $(BDIRS)")]).unwrap();
     if lines_replaced != 2 {
         panic!("Replaced {} lines in Makefile, expected 1", lines_replaced);
     }

--- a/build.rs
+++ b/build.rs
@@ -1,52 +1,52 @@
 // build.rs
-use std::process::Command;
 use std::env;
 use std::fs;
-use std::io::{BufReader,BufWriter,BufRead,Write};
 use std::fs::File;
-use std::path::{Path,PathBuf};
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 const PACKAGE_URL: &str = "https://github.com/ivmai/cudd/archive/refs/tags/cudd-2.5.1.tar.gz";
 const PACKAGE_MD5: &str = "42283a52ff815c5ca8231b6927318fbf";
 
 #[derive(Debug)]
 enum FetchError {
-    CommandError( std::process::ExitStatus ),
-    IOError( std::io::Error ),
-    PathExists
+    CommandError(std::process::ExitStatus),
+    IOError(std::io::Error),
+    PathExists,
 }
 
 enum MD5Status {
     Match,
     Mismatch,
-    Unknown
+    Unknown,
 }
 
 impl From<std::io::Error> for FetchError {
     fn from(err: std::io::Error) -> FetchError {
-        FetchError::IOError( err )
+        FetchError::IOError(err)
     }
 }
 
 /// Run a command and return (stdout, stderr) if exit status is success.
-fn run_command( cmd: &mut Command ) -> Result<(String, String), FetchError>
-{
+fn run_command(cmd: &mut Command) -> Result<(String, String), FetchError> {
     let output = cmd.output()?;
 
     return if output.status.success() {
-        Ok((String::from_utf8(output.stdout).unwrap(),
-            String::from_utf8(output.stderr).unwrap()))
+        Ok((
+            String::from_utf8(output.stdout).unwrap(),
+            String::from_utf8(output.stderr).unwrap(),
+        ))
     } else {
         println!("Command {:?} exited with status {}", cmd, output.status);
         Err(FetchError::CommandError(output.status))
-    }
+    };
 }
 
 /// Fetch a file from a URL if it does not already exist in out_dir and verify its md5sum if possible.
-fn fetch_package(out_dir: &str, url: &str, md5: &str) -> Result<(PathBuf, MD5Status), FetchError>
-{
-    let out_path        = Path::new(&out_dir);
-    let target_path     = out_path.join( Path::new(url).file_name().unwrap() );
+fn fetch_package(out_dir: &str, url: &str, md5: &str) -> Result<(PathBuf, MD5Status), FetchError> {
+    let out_path = Path::new(&out_dir);
+    let target_path = out_path.join(Path::new(url).file_name().unwrap());
 
     let md5_result = {
         let target_path_str = target_path.to_str().unwrap();
@@ -54,38 +54,48 @@ fn fetch_package(out_dir: &str, url: &str, md5: &str) -> Result<(PathBuf, MD5Sta
 
         match meta {
             Ok(m) => {
-                if m.is_file() { println!("{} already exists, skipping download", target_path_str) }
-                else { return Err(FetchError::PathExists) }
-            },
+                if m.is_file() {
+                    println!("{} already exists, skipping download", target_path_str)
+                } else {
+                    return Err(FetchError::PathExists);
+                }
+            }
             Err(e) => {
                 if e.kind() == std::io::ErrorKind::NotFound {
                     println!("Downloading {} to {}", url, target_path_str);
-                    run_command( &mut Command::new("curl").args(&["-L", url, "-o", target_path_str]) )?;
+                    run_command(&mut Command::new("curl").args(&[
+                        "-L",
+                        url,
+                        "-o",
+                        target_path_str,
+                    ]))?;
                 } else {
-                    return Err( FetchError::IOError(e) );
+                    return Err(FetchError::IOError(e));
                 }
             }
         }
 
-        run_command( &mut Command::new("md5sum").arg(target_path_str) ).or_else(|_|
-            run_command( &mut Command::new("md5").arg(target_path_str) ))
+        run_command(&mut Command::new("md5sum").arg(target_path_str))
+            .or_else(|_| run_command(&mut Command::new("md5").arg(target_path_str)))
     };
 
-    Ok(
-        (target_path,
+    Ok((
+        target_path,
         match md5_result {
-            Err( _ ) => MD5Status::Unknown,
-            Ok( (out,_) ) => {
+            Err(_) => MD5Status::Unknown,
+            Ok((out, _)) => {
                 // md5sum outputs "<md5> <file>", md5 on OSX outputs "MD5 (<file>) = <md5>"
-                if out.contains(md5) { MD5Status::Match }
-                else { MD5Status::Mismatch }
+                if out.contains(md5) {
+                    MD5Status::Match
+                } else {
+                    MD5Status::Mismatch
+                }
             }
-        }))
-
+        },
+    ))
 }
 
-fn replace_lines( path: &Path, replacements: Vec<(&str,&str)> ) -> Result< u32, std::io::Error >
-{
+fn replace_lines(path: &Path, replacements: Vec<(&str, &str)>) -> Result<u32, std::io::Error> {
     let mut lines_replaced = 0;
     let new_path = path.with_extension(".new");
 
@@ -111,48 +121,72 @@ fn replace_lines( path: &Path, replacements: Vec<(&str,&str)> ) -> Result< u32, 
     fs::remove_file(&path)?;
     fs::rename(&new_path, &path)?;
 
-    Ok( lines_replaced )
+    Ok(lines_replaced)
 }
 
 fn main() {
     let out_dir = env::var("OUT_DIR").unwrap();
 
-    let (tar_path, md5_status) = fetch_package( &out_dir, PACKAGE_URL, PACKAGE_MD5 ).unwrap();
+    let (tar_path, md5_status) = fetch_package(&out_dir, PACKAGE_URL, PACKAGE_MD5).unwrap();
 
     match md5_status {
         MD5Status::Match => (),
-        MD5Status::Unknown => println!( "No md5 available, skipping package validation" ),
-        MD5Status::Mismatch => panic!( "MD5 mismatch on package" )
+        MD5Status::Unknown => println!("No md5 available, skipping package validation"),
+        MD5Status::Mismatch => panic!("MD5 mismatch on package"),
     }
 
-    let untarred_path = tar_path.with_extension("").with_extension(""); // kill .tar and .gz    
-    if !untarred_path.exists() { // Create the destination directory.
+    let untarred_path = tar_path.with_extension("").with_extension(""); // kill .tar and .gz
+    if !untarred_path.exists() {
+        // Create the destination directory.
         std::fs::create_dir_all(untarred_path.clone()).unwrap();
     }
-        
+
     // untar package, ignoring the name of the top level folder, dumping into untarred_path instead.
-    let untarred_path_str = untarred_path.clone().into_os_string().into_string().unwrap();    
-    run_command( Command::new("tar").args(&["xf", tar_path.to_str().unwrap(), "--strip-components=1", "-C", &untarred_path_str]) ).unwrap();
+    let untarred_path_str = untarred_path
+        .clone()
+        .into_os_string()
+        .into_string()
+        .unwrap();
+    run_command(Command::new("tar").args(&[
+        "xf",
+        tar_path.to_str().unwrap(),
+        "--strip-components=1",
+        "-C",
+        &untarred_path_str,
+    ]))
+    .unwrap();
 
     // patch Makefile
     let lines_replaced = replace_lines(
         &untarred_path.join("Makefile"),
-        vec![// need PIC so our rust lib can be dynamically linked
-            ("ICFLAGS\t= -g -O3",
-             "ICFLAGS\t= -g -O3 -fPIC"),
+        vec![
+            // need PIC so our rust lib can be dynamically linked
+            ("ICFLAGS\t= -g -O3", "ICFLAGS\t= -g -O3 -fPIC"),
             // remove "nanotrav" from DIRS, it doesn't compile on OSX
-            ("DIRS\t= $(BDIRS)", // (matches prefix)
-             "DIRS\t= $(BDIRS)")]).unwrap();
+            (
+                "DIRS\t= $(BDIRS)", // (matches prefix)
+                "DIRS\t= $(BDIRS)",
+            ),
+        ],
+    )
+    .unwrap();
     if lines_replaced != 2 {
         panic!("Replaced {} lines in Makefile, expected 1", lines_replaced);
     }
 
     // build libraries (execute make)
-    run_command( Command::new("make").current_dir(&untarred_path) ).unwrap();
+    run_command(Command::new("make").current_dir(&untarred_path)).unwrap();
 
     // Move all libs to output directory so we don't have to specify each directory
-    run_command( Command::new("sh").current_dir(&out_dir).args(&["-c", "cp cudd-*/*/*.a ."]) ).unwrap();
+    run_command(
+        Command::new("sh")
+            .current_dir(&out_dir)
+            .args(&["-c", "cp cudd-*/*/*.a ."]),
+    )
+    .unwrap();
 
     println!("cargo:rustc-flags=-L {}", out_dir);
-    println!("cargo:rustc-flags=-l static=cudd -l static=mtr -l static=util -l static=epd -l static=st");
+    println!(
+        "cargo:rustc-flags=-l static=cudd -l static=mtr -l static=util -l static=epd -l static=st"
+    );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(non_camel_case_types)] // Allow non-idiomatic names in the whole crate.
 extern crate libc;
 
-use libc::{c_void,c_uint,c_long,c_ulong,c_int,c_char,c_double,FILE};
+use libc::{c_char, c_double, c_int, c_long, c_uint, c_ulong, c_void, FILE};
 
 pub static CUDD_TRUE: c_uint = 1;
 pub static CUDD_FALSE: c_uint = 0;
@@ -24,7 +24,8 @@ pub static CUDD_RESIDUE_TC: c_uint = 2;
 pub enum Cudd_ReorderingType {
     CUDD_REORDER_SAME,
     CUDD_REORDER_NONE,
-    CUDD_REORDER_RANDOM, CUDD_REORDER_RANDOM_PIVOT,
+    CUDD_REORDER_RANDOM,
+    CUDD_REORDER_RANDOM_PIVOT,
     CUDD_REORDER_SIFT,
     CUDD_REORDER_SIFT_CONVERGE,
     CUDD_REORDER_SYMM_SIFT,
@@ -42,7 +43,7 @@ pub enum Cudd_ReorderingType {
     CUDD_REORDER_LINEAR,
     CUDD_REORDER_LINEAR_CONVERGE,
     CUDD_REORDER_LAZY_SIFT,
-    CUDD_REORDER_EXACT
+    CUDD_REORDER_EXACT,
 }
 
 #[repr(C)]
@@ -57,7 +58,7 @@ pub enum Cudd_AggregationType {
     CUDD_GROUP_CHECK6,
     CUDD_GROUP_CHECK7,
     CUDD_GROUP_CHECK8,
-    CUDD_GROUP_CHECK9
+    CUDD_GROUP_CHECK9,
 }
 
 #[repr(C)]
@@ -66,7 +67,7 @@ pub enum Cudd_HookType {
     CUDD_PRE_GC_HOOK,
     CUDD_POST_GC_HOOK,
     CUDD_PRE_REORDERING_HOOK,
-    CUDD_POST_REORDERING_HOOK
+    CUDD_POST_REORDERING_HOOK,
 }
 
 #[repr(C)]
@@ -79,7 +80,7 @@ pub enum Cudd_ErrorType {
     CUDD_TIMEOUT_EXPIRED,
     CUDD_TERMINATION,
     CUDD_INVALID_ARG,
-    CUDD_INTERNAL_ERROR
+    CUDD_INTERNAL_ERROR,
 }
 
 #[repr(C)]
@@ -88,7 +89,7 @@ pub enum Cudd_LazyGroupType {
     CUDD_LAZY_NONE,
     CUDD_LAZY_SOFT_GROUP,
     CUDD_LAZY_HARD_GROUP,
-    CUDD_LAZY_UNGROUP
+    CUDD_LAZY_UNGROUP,
 }
 
 #[repr(C)]
@@ -96,7 +97,7 @@ pub enum Cudd_LazyGroupType {
 pub enum Cudd_VariableType {
     CUDD_VAR_PRIMARY_INPUT,
     CUDD_VAR_PRESENT_STATE,
-    CUDD_VAR_NEXT_STATE
+    CUDD_VAR_NEXT_STATE,
 }
 
 #[cfg(all(target_pointer_width = "32"))]
@@ -106,12 +107,11 @@ pub type DdHalfWord = libc::uint16_t;
 pub type DdHalfWord = u32;
 
 #[repr(C)]
-pub struct DdNode
-{
+pub struct DdNode {
     index: DdHalfWord,
     ref_count: DdHalfWord,
     next: *mut DdNode,
-    union_data: [c_uint; 2]
+    union_data: [c_uint; 2],
 }
 
 pub type DdManager = c_void;
@@ -120,7 +120,7 @@ pub type MtrNode = c_void;
 pub type DdTlcInfo = c_void;
 
 #[allow(dead_code)]
-extern {
+extern "C" {
     pub fn Cudd_addNewVar(dd: *mut DdManager) -> *mut DdNode;
     pub fn Cudd_addNewVarAtLevel(dd: *mut DdManager, level: c_int) -> *mut DdNode;
     pub fn Cudd_bddNewVar(dd: *mut DdManager) -> *mut DdNode;
@@ -130,7 +130,7 @@ extern {
     pub fn Cudd_bddIthVar(dd: *mut DdManager, i: c_int) -> *mut DdNode;
     pub fn Cudd_zddIthVar(dd: *mut DdManager, i: c_int) -> *mut DdNode;
     pub fn Cudd_zddVarsFromBddVars(dd: *mut DdManager, multiplicity: c_int) -> c_int;
-    pub fn Cudd_addConst(dd: *mut DdManager, c: CUDD_VALUE_TYPE ) -> *mut DdNode;
+    pub fn Cudd_addConst(dd: *mut DdManager, c: CUDD_VALUE_TYPE) -> *mut DdNode;
     pub fn Cudd_IsNonConstant(f: *mut DdNode) -> c_int;
     pub fn Cudd_ReadStartTime(unique: *mut DdManager) -> c_ulong;
     pub fn Cudd_ReadElapsedTime(unique: *mut DdManager) -> c_ulong;
@@ -144,12 +144,16 @@ extern {
     pub fn Cudd_TimeLimited(unique: *mut DdManager) -> c_int;
     //pub fn Cudd_RegisterTerminationCallback(unique: *mut DdManager, callback: c_DD_THFP, callback_arg: *mut c_void) -> c_void;
     pub fn Cudd_UnregisterTerminationCallback(unique: *mut DdManager) -> c_void;
-    pub fn Cudd_AutodynEnable(unique: *mut DdManager, method: Cudd_ReorderingType ) -> c_void;
+    pub fn Cudd_AutodynEnable(unique: *mut DdManager, method: Cudd_ReorderingType) -> c_void;
     pub fn Cudd_AutodynDisable(unique: *mut DdManager) -> c_void;
-    pub fn Cudd_ReorderingStatus(unique: *mut DdManager, method: *mut Cudd_ReorderingType) -> c_int;
-    pub fn Cudd_AutodynEnableZdd(unique: *mut DdManager, method: Cudd_ReorderingType ) -> c_void;
+    pub fn Cudd_ReorderingStatus(unique: *mut DdManager, method: *mut Cudd_ReorderingType)
+        -> c_int;
+    pub fn Cudd_AutodynEnableZdd(unique: *mut DdManager, method: Cudd_ReorderingType) -> c_void;
     pub fn Cudd_AutodynDisableZdd(unique: *mut DdManager) -> c_void;
-    pub fn Cudd_ReorderingStatusZdd(unique: *mut DdManager, method: *mut Cudd_ReorderingType) -> c_int;
+    pub fn Cudd_ReorderingStatusZdd(
+        unique: *mut DdManager,
+        method: *mut Cudd_ReorderingType,
+    ) -> c_int;
     pub fn Cudd_zddRealignmentEnabled(unique: *mut DdManager) -> c_int;
     pub fn Cudd_zddRealignEnable(unique: *mut DdManager) -> c_void;
     pub fn Cudd_zddRealignDisable(unique: *mut DdManager) -> c_void;
@@ -216,10 +220,10 @@ extern {
     pub fn Cudd_ReadInvPerm(dd: *mut DdManager, i: c_int) -> c_int;
     pub fn Cudd_ReadInvPermZdd(dd: *mut DdManager, i: c_int) -> c_int;
     pub fn Cudd_ReadVars(dd: *mut DdManager, i: c_int) -> *mut DdNode;
-    pub fn Cudd_ReadEpsilon(dd: *mut DdManager) -> CUDD_VALUE_TYPE ;
-    pub fn Cudd_SetEpsilon(dd: *mut DdManager, ep: CUDD_VALUE_TYPE ) -> c_void;
-    pub fn Cudd_ReadGroupcheck(dd: *mut DdManager) -> Cudd_AggregationType ;
-    pub fn Cudd_SetGroupcheck(dd: *mut DdManager, gc: Cudd_AggregationType ) -> c_void;
+    pub fn Cudd_ReadEpsilon(dd: *mut DdManager) -> CUDD_VALUE_TYPE;
+    pub fn Cudd_SetEpsilon(dd: *mut DdManager, ep: CUDD_VALUE_TYPE) -> c_void;
+    pub fn Cudd_ReadGroupcheck(dd: *mut DdManager) -> Cudd_AggregationType;
+    pub fn Cudd_SetGroupcheck(dd: *mut DdManager, gc: Cudd_AggregationType) -> c_void;
     pub fn Cudd_GarbageCollectionEnabled(dd: *mut DdManager) -> c_int;
     pub fn Cudd_EnableGarbageCollection(dd: *mut DdManager) -> c_void;
     pub fn Cudd_DisableGarbageCollection(dd: *mut DdManager) -> c_void;
@@ -252,13 +256,14 @@ extern {
     pub fn Cudd_EnableReorderingReporting(dd: *mut DdManager) -> c_int;
     pub fn Cudd_DisableReorderingReporting(dd: *mut DdManager) -> c_int;
     pub fn Cudd_ReorderingReporting(dd: *mut DdManager) -> c_int;
-    pub fn Cudd_PrintGroupedOrder(dd: *mut DdManager, str: *mut c_char, data: *mut c_void) -> c_int;
+    pub fn Cudd_PrintGroupedOrder(dd: *mut DdManager, str: *mut c_char, data: *mut c_void)
+        -> c_int;
     pub fn Cudd_EnableOrderingMonitoring(dd: *mut DdManager) -> c_int;
     pub fn Cudd_DisableOrderingMonitoring(dd: *mut DdManager) -> c_int;
     pub fn Cudd_OrderingMonitoring(dd: *mut DdManager) -> c_int;
     pub fn Cudd_SetApplicationHook(dd: *mut DdManager, value: *mut c_void) -> c_void;
     pub fn Cudd_ReadApplicationHook(dd: *mut DdManager) -> *mut c_void;
-    pub fn Cudd_ReadErrorCode(dd: *mut DdManager) -> Cudd_ErrorType ;
+    pub fn Cudd_ReadErrorCode(dd: *mut DdManager) -> Cudd_ErrorType;
     pub fn Cudd_ClearErrorCode(dd: *mut DdManager) -> c_void;
     pub fn Cudd_ReadStdout(dd: *mut DdManager) -> *mut FILE;
     pub fn Cudd_SetStdout(dd: *mut DdManager, fp: *mut FILE) -> c_void;
@@ -274,45 +279,147 @@ extern {
     pub fn Cudd_bddBindVar(dd: *mut DdManager, index: c_int) -> c_int;
     pub fn Cudd_bddUnbindVar(dd: *mut DdManager, index: c_int) -> c_int;
     pub fn Cudd_bddVarIsBound(dd: *mut DdManager, index: c_int) -> c_int;
-    pub fn Cudd_addExistAbstract(manager: *mut DdManager, f: *mut DdNode, cube: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addUnivAbstract(manager: *mut DdManager, f: *mut DdNode, cube: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addOrAbstract(manager: *mut DdManager, f: *mut DdNode, cube: *mut DdNode) -> *mut DdNode;
+    pub fn Cudd_addExistAbstract(
+        manager: *mut DdManager,
+        f: *mut DdNode,
+        cube: *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addUnivAbstract(
+        manager: *mut DdManager,
+        f: *mut DdNode,
+        cube: *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addOrAbstract(
+        manager: *mut DdManager,
+        f: *mut DdNode,
+        cube: *mut DdNode,
+    ) -> *mut DdNode;
     //M1: extern DdNode * Cudd_addApply (DdManager *dd, DdNode * (*)(DdManager *, DdNode **, DdNode **), DdNode *f, DdNode *g);
 
-    pub fn Cudd_addPlus(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addTimes(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addThreshold(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addSetNZ(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addDivide(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addMinus(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addMinimum(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addMaximum(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addOneZeroMaximum(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addDiff(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addAgreement(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode) -> *mut DdNode;
+    pub fn Cudd_addPlus(
+        dd: *mut DdManager,
+        f: *mut *mut DdNode,
+        g: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addTimes(
+        dd: *mut DdManager,
+        f: *mut *mut DdNode,
+        g: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addThreshold(
+        dd: *mut DdManager,
+        f: *mut *mut DdNode,
+        g: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addSetNZ(
+        dd: *mut DdManager,
+        f: *mut *mut DdNode,
+        g: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addDivide(
+        dd: *mut DdManager,
+        f: *mut *mut DdNode,
+        g: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addMinus(
+        dd: *mut DdManager,
+        f: *mut *mut DdNode,
+        g: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addMinimum(
+        dd: *mut DdManager,
+        f: *mut *mut DdNode,
+        g: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addMaximum(
+        dd: *mut DdManager,
+        f: *mut *mut DdNode,
+        g: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addOneZeroMaximum(
+        dd: *mut DdManager,
+        f: *mut *mut DdNode,
+        g: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addDiff(
+        dd: *mut DdManager,
+        f: *mut *mut DdNode,
+        g: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addAgreement(
+        dd: *mut DdManager,
+        f: *mut *mut DdNode,
+        g: *mut *mut DdNode,
+    ) -> *mut DdNode;
     pub fn Cudd_addOr(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addNand(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addNor(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addXor(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addXnor(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode) -> *mut DdNode;
+    pub fn Cudd_addNand(
+        dd: *mut DdManager,
+        f: *mut *mut DdNode,
+        g: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addNor(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode)
+        -> *mut DdNode;
+    pub fn Cudd_addXor(dd: *mut DdManager, f: *mut *mut DdNode, g: *mut *mut DdNode)
+        -> *mut DdNode;
+    pub fn Cudd_addXnor(
+        dd: *mut DdManager,
+        f: *mut *mut DdNode,
+        g: *mut *mut DdNode,
+    ) -> *mut DdNode;
     //M1: extern DdNode * Cudd_addMonadicApply (DdManager * dd, DdNode * (*op)(DdManager *, DdNode *), DdNode * f);
 
     pub fn Cudd_addLog(dd: *mut DdManager, f: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_addFindMax(dd: *mut DdManager, f: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_addFindMin(dd: *mut DdManager, f: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_addIthBit(dd: *mut DdManager, f: *mut DdNode, bit: c_int) -> *mut DdNode;
-    pub fn Cudd_addScalarInverse(dd: *mut DdManager, f: *mut DdNode, epsilon: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addIte(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode, h: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addIteConstant(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode, h: *mut DdNode) -> *mut DdNode;
+    pub fn Cudd_addScalarInverse(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        epsilon: *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addIte(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        h: *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addIteConstant(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        h: *mut DdNode,
+    ) -> *mut DdNode;
     pub fn Cudd_addEvalConst(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_addLeq(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode) -> c_int;
     pub fn Cudd_addCmpl(dd: *mut DdManager, f: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_addNegate(dd: *mut DdManager, f: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_addRoundOff(dd: *mut DdManager, f: *mut DdNode, N: c_int) -> *mut DdNode;
-    pub fn Cudd_addWalsh(dd: *mut DdManager, x: *mut *mut DdNode, y: *mut *mut DdNode, n: c_int) -> *mut DdNode;
-    pub fn Cudd_addResidue(dd: *mut DdManager, n: c_int, m: c_int, options: c_int, top: c_int) -> *mut DdNode;
-    pub fn Cudd_bddAndAbstract(manager: *mut DdManager, f: *mut DdNode, g: *mut DdNode, cube: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_bddAndAbstractLimit(manager: *mut DdManager, f: *mut DdNode, g: *mut DdNode, cube: *mut DdNode, limit: c_uint) -> *mut DdNode;
+    pub fn Cudd_addWalsh(
+        dd: *mut DdManager,
+        x: *mut *mut DdNode,
+        y: *mut *mut DdNode,
+        n: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_addResidue(
+        dd: *mut DdManager,
+        n: c_int,
+        m: c_int,
+        options: c_int,
+        top: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_bddAndAbstract(
+        manager: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        cube: *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_bddAndAbstractLimit(
+        manager: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        cube: *mut DdNode,
+        limit: c_uint,
+    ) -> *mut DdNode;
     pub fn Cudd_ApaNumberOfDigits(binaryDigits: c_int) -> c_int;
     /*
     pub fn Cudd_NewApaNumber(digits: c_int) -> c_DdApaNumber;
@@ -334,80 +441,356 @@ extern {
     pub fn Cudd_ApaPrintMintermExp(fp: *mut FILE, dd: *mut DdManager, node: *mut DdNode, nvars: c_int, precision: c_int) -> c_int;
     pub fn Cudd_ApaPrintDensity(fp: *mut FILE, dd: *mut DdManager, node: *mut DdNode, nvars: c_int) -> c_int;
     */
-    pub fn Cudd_UnderApprox(dd: *mut DdManager, f: *mut DdNode, numVars: c_int, threshold: c_int, safe: c_int, quality: c_double) -> *mut DdNode;
-    pub fn Cudd_OverApprox(dd: *mut DdManager, f: *mut DdNode, numVars: c_int, threshold: c_int, safe: c_int, quality: c_double) -> *mut DdNode;
-    pub fn Cudd_RemapUnderApprox(dd: *mut DdManager, f: *mut DdNode, numVars: c_int, threshold: c_int, quality: c_double) -> *mut DdNode;
-    pub fn Cudd_RemapOverApprox(dd: *mut DdManager, f: *mut DdNode, numVars: c_int, threshold: c_int, quality: c_double) -> *mut DdNode;
-    pub fn Cudd_BiasedUnderApprox(dd: *mut DdManager, f: *mut DdNode, b: *mut DdNode, numVars: c_int, threshold: c_int, quality1: c_double, quality0: c_double) -> *mut DdNode;
-    pub fn Cudd_BiasedOverApprox(dd: *mut DdManager, f: *mut DdNode, b: *mut DdNode, numVars: c_int, threshold: c_int, quality1: c_double, quality0: c_double) -> *mut DdNode;
-    pub fn Cudd_bddExistAbstract(manager: *mut DdManager, f: *mut DdNode, cube: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_bddExistAbstractLimit(manager: *mut DdManager, f: *mut DdNode, cube: *mut DdNode, limit: c_uint) -> *mut DdNode;
-    pub fn Cudd_bddXorExistAbstract(manager: *mut DdManager, f: *mut DdNode, g: *mut DdNode, cube: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_bddUnivAbstract(manager: *mut DdManager, f: *mut DdNode, cube: *mut DdNode) -> *mut DdNode;
+    pub fn Cudd_UnderApprox(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        numVars: c_int,
+        threshold: c_int,
+        safe: c_int,
+        quality: c_double,
+    ) -> *mut DdNode;
+    pub fn Cudd_OverApprox(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        numVars: c_int,
+        threshold: c_int,
+        safe: c_int,
+        quality: c_double,
+    ) -> *mut DdNode;
+    pub fn Cudd_RemapUnderApprox(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        numVars: c_int,
+        threshold: c_int,
+        quality: c_double,
+    ) -> *mut DdNode;
+    pub fn Cudd_RemapOverApprox(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        numVars: c_int,
+        threshold: c_int,
+        quality: c_double,
+    ) -> *mut DdNode;
+    pub fn Cudd_BiasedUnderApprox(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        b: *mut DdNode,
+        numVars: c_int,
+        threshold: c_int,
+        quality1: c_double,
+        quality0: c_double,
+    ) -> *mut DdNode;
+    pub fn Cudd_BiasedOverApprox(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        b: *mut DdNode,
+        numVars: c_int,
+        threshold: c_int,
+        quality1: c_double,
+        quality0: c_double,
+    ) -> *mut DdNode;
+    pub fn Cudd_bddExistAbstract(
+        manager: *mut DdManager,
+        f: *mut DdNode,
+        cube: *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_bddExistAbstractLimit(
+        manager: *mut DdManager,
+        f: *mut DdNode,
+        cube: *mut DdNode,
+        limit: c_uint,
+    ) -> *mut DdNode;
+    pub fn Cudd_bddXorExistAbstract(
+        manager: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        cube: *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_bddUnivAbstract(
+        manager: *mut DdManager,
+        f: *mut DdNode,
+        cube: *mut DdNode,
+    ) -> *mut DdNode;
     pub fn Cudd_bddBooleanDiff(manager: *mut DdManager, f: *mut DdNode, x: c_int) -> *mut DdNode;
     pub fn Cudd_bddVarIsDependent(dd: *mut DdManager, f: *mut DdNode, var: *mut DdNode) -> c_int;
-    pub fn Cudd_bddCorrelation(manager: *mut DdManager, f: *mut DdNode, g: *mut DdNode) -> c_double;
-    pub fn Cudd_bddCorrelationWeights(manager: *mut DdManager, f: *mut DdNode, g: *mut DdNode, prob: *mut c_double) -> c_double;
-    pub fn Cudd_bddIte(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode, h: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_bddIteConstant(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode, h: *mut DdNode) -> *mut DdNode;
+    pub fn Cudd_bddCorrelation(manager: *mut DdManager, f: *mut DdNode, g: *mut DdNode)
+        -> c_double;
+    pub fn Cudd_bddCorrelationWeights(
+        manager: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        prob: *mut c_double,
+    ) -> c_double;
+    pub fn Cudd_bddIte(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        h: *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_bddIteConstant(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        h: *mut DdNode,
+    ) -> *mut DdNode;
     pub fn Cudd_bddIntersect(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_bddAnd(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_bddAndLimit(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode, limit: c_uint) -> *mut DdNode;
+    pub fn Cudd_bddAndLimit(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        limit: c_uint,
+    ) -> *mut DdNode;
     pub fn Cudd_bddOr(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_bddOrLimit(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode, limit: c_uint) -> *mut DdNode;
+    pub fn Cudd_bddOrLimit(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        limit: c_uint,
+    ) -> *mut DdNode;
     pub fn Cudd_bddNand(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_bddNor(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_bddXor(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_bddXnor(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_bddXnorLimit(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode, limit: c_uint) -> *mut DdNode;
+    pub fn Cudd_bddXnorLimit(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        limit: c_uint,
+    ) -> *mut DdNode;
     pub fn Cudd_bddLeq(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode) -> c_int;
-    pub fn Cudd_addBddThreshold(dd: *mut DdManager, f: *mut DdNode, value: CUDD_VALUE_TYPE ) -> *mut DdNode;
-    pub fn Cudd_addBddStrictThreshold(dd: *mut DdManager, f: *mut DdNode, value: CUDD_VALUE_TYPE ) -> *mut DdNode;
-    pub fn Cudd_addBddInterval(dd: *mut DdManager, f: *mut DdNode, lower: CUDD_VALUE_TYPE , upper: CUDD_VALUE_TYPE ) -> *mut DdNode;
+    pub fn Cudd_addBddThreshold(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        value: CUDD_VALUE_TYPE,
+    ) -> *mut DdNode;
+    pub fn Cudd_addBddStrictThreshold(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        value: CUDD_VALUE_TYPE,
+    ) -> *mut DdNode;
+    pub fn Cudd_addBddInterval(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        lower: CUDD_VALUE_TYPE,
+        upper: CUDD_VALUE_TYPE,
+    ) -> *mut DdNode;
     pub fn Cudd_addBddIthBit(dd: *mut DdManager, f: *mut DdNode, bit: c_int) -> *mut DdNode;
     pub fn Cudd_BddToAdd(dd: *mut DdManager, B: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_addBddPattern(dd: *mut DdManager, f: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_bddTransfer(ddSource: *mut DdManager, ddDestination: *mut DdManager, f: *mut DdNode) -> *mut DdNode;
+    pub fn Cudd_bddTransfer(
+        ddSource: *mut DdManager,
+        ddDestination: *mut DdManager,
+        f: *mut DdNode,
+    ) -> *mut DdNode;
     pub fn Cudd_DebugCheck(table: *mut DdManager) -> c_int;
     pub fn Cudd_CheckKeys(table: *mut DdManager) -> c_int;
-    pub fn Cudd_bddClippingAnd(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode, maxDepth: c_int, direction: c_int) -> *mut DdNode;
-    pub fn Cudd_bddClippingAndAbstract(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode, cube: *mut DdNode, maxDepth: c_int, direction: c_int) -> *mut DdNode;
+    pub fn Cudd_bddClippingAnd(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        maxDepth: c_int,
+        direction: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_bddClippingAndAbstract(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        cube: *mut DdNode,
+        maxDepth: c_int,
+        direction: c_int,
+    ) -> *mut DdNode;
     pub fn Cudd_Cofactor(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_CheckCube(dd: *mut DdManager, g: *mut DdNode) -> c_int;
-    pub fn Cudd_bddCompose(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode, v: c_int) -> *mut DdNode;
-    pub fn Cudd_addCompose(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode, v: c_int) -> *mut DdNode;
-    pub fn Cudd_addPermute(manager: *mut DdManager, node: *mut DdNode, permut: *mut c_int) -> *mut DdNode;
-    pub fn Cudd_addSwapVariables(dd: *mut DdManager, f: *mut DdNode, x: *mut *mut DdNode, y: *mut *mut DdNode, n: c_int) -> *mut DdNode;
-    pub fn Cudd_bddPermute(manager: *mut DdManager, node: *mut DdNode, permut: *mut c_int) -> *mut DdNode;
+    pub fn Cudd_bddCompose(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        v: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_addCompose(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        v: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_addPermute(
+        manager: *mut DdManager,
+        node: *mut DdNode,
+        permut: *mut c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_addSwapVariables(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        x: *mut *mut DdNode,
+        y: *mut *mut DdNode,
+        n: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_bddPermute(
+        manager: *mut DdManager,
+        node: *mut DdNode,
+        permut: *mut c_int,
+    ) -> *mut DdNode;
     pub fn Cudd_bddVarMap(manager: *mut DdManager, f: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_SetVarMap(manager: *mut DdManager, x: *mut *mut DdNode, y: *mut *mut DdNode, n: c_int) -> c_int;
-    pub fn Cudd_bddSwapVariables(dd: *mut DdManager, f: *mut DdNode, x: *mut *mut DdNode, y: *mut *mut DdNode, n: c_int) -> *mut DdNode;
-    pub fn Cudd_bddAdjPermuteX(dd: *mut DdManager, B: *mut DdNode, x: *mut *mut DdNode, n: c_int) -> *mut DdNode;
-    pub fn Cudd_addVectorCompose(dd: *mut DdManager, f: *mut DdNode, vector: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addGeneralVectorCompose(dd: *mut DdManager, f: *mut DdNode, vectorOn: *mut *mut DdNode, vectorOff: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addNonSimCompose(dd: *mut DdManager, f: *mut DdNode, vector: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_bddVectorCompose(dd: *mut DdManager, f: *mut DdNode, vector: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_bddApproxConjDecomp(dd: *mut DdManager, f: *mut DdNode, conjuncts: *mut *mut *mut DdNode) -> c_int;
-    pub fn Cudd_bddApproxDisjDecomp(dd: *mut DdManager, f: *mut DdNode, disjuncts: *mut *mut *mut DdNode) -> c_int;
-    pub fn Cudd_bddIterConjDecomp(dd: *mut DdManager, f: *mut DdNode, conjuncts: *mut *mut *mut DdNode) -> c_int;
-    pub fn Cudd_bddIterDisjDecomp(dd: *mut DdManager, f: *mut DdNode, disjuncts: *mut *mut *mut DdNode) -> c_int;
-    pub fn Cudd_bddGenConjDecomp(dd: *mut DdManager, f: *mut DdNode, conjuncts: *mut *mut *mut DdNode) -> c_int;
-    pub fn Cudd_bddGenDisjDecomp(dd: *mut DdManager, f: *mut DdNode, disjuncts: *mut *mut *mut DdNode) -> c_int;
-    pub fn Cudd_bddVarConjDecomp(dd: *mut DdManager, f: *mut DdNode, conjuncts: *mut *mut *mut DdNode) -> c_int;
-    pub fn Cudd_bddVarDisjDecomp(dd: *mut DdManager, f: *mut DdNode, disjuncts: *mut *mut *mut DdNode) -> c_int;
+    pub fn Cudd_SetVarMap(
+        manager: *mut DdManager,
+        x: *mut *mut DdNode,
+        y: *mut *mut DdNode,
+        n: c_int,
+    ) -> c_int;
+    pub fn Cudd_bddSwapVariables(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        x: *mut *mut DdNode,
+        y: *mut *mut DdNode,
+        n: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_bddAdjPermuteX(
+        dd: *mut DdManager,
+        B: *mut DdNode,
+        x: *mut *mut DdNode,
+        n: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_addVectorCompose(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        vector: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addGeneralVectorCompose(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        vectorOn: *mut *mut DdNode,
+        vectorOff: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addNonSimCompose(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        vector: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_bddVectorCompose(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        vector: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_bddApproxConjDecomp(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        conjuncts: *mut *mut *mut DdNode,
+    ) -> c_int;
+    pub fn Cudd_bddApproxDisjDecomp(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        disjuncts: *mut *mut *mut DdNode,
+    ) -> c_int;
+    pub fn Cudd_bddIterConjDecomp(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        conjuncts: *mut *mut *mut DdNode,
+    ) -> c_int;
+    pub fn Cudd_bddIterDisjDecomp(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        disjuncts: *mut *mut *mut DdNode,
+    ) -> c_int;
+    pub fn Cudd_bddGenConjDecomp(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        conjuncts: *mut *mut *mut DdNode,
+    ) -> c_int;
+    pub fn Cudd_bddGenDisjDecomp(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        disjuncts: *mut *mut *mut DdNode,
+    ) -> c_int;
+    pub fn Cudd_bddVarConjDecomp(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        conjuncts: *mut *mut *mut DdNode,
+    ) -> c_int;
+    pub fn Cudd_bddVarDisjDecomp(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        disjuncts: *mut *mut *mut DdNode,
+    ) -> c_int;
     pub fn Cudd_FindEssential(dd: *mut DdManager, f: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_bddIsVarEssential(manager: *mut DdManager, f: *mut DdNode, id: c_int, phase: c_int) -> c_int;
+    pub fn Cudd_bddIsVarEssential(
+        manager: *mut DdManager,
+        f: *mut DdNode,
+        id: c_int,
+        phase: c_int,
+    ) -> c_int;
     pub fn Cudd_FindTwoLiteralClauses(dd: *mut DdManager, f: *mut DdNode) -> *mut DdTlcInfo;
-    pub fn Cudd_PrintTwoLiteralClauses(dd: *mut DdManager, f: *mut DdNode, names: *mut *mut c_char, fp: *mut FILE) -> c_int;
-    pub fn Cudd_ReadIthClause(tlc: *mut DdTlcInfo, i: c_int, var1: *mut DdHalfWord, var2: *mut DdHalfWord, phase1: *mut c_int, phase2: *mut c_int) -> c_int;
+    pub fn Cudd_PrintTwoLiteralClauses(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        names: *mut *mut c_char,
+        fp: *mut FILE,
+    ) -> c_int;
+    pub fn Cudd_ReadIthClause(
+        tlc: *mut DdTlcInfo,
+        i: c_int,
+        var1: *mut DdHalfWord,
+        var2: *mut DdHalfWord,
+        phase1: *mut c_int,
+        phase2: *mut c_int,
+    ) -> c_int;
     pub fn Cudd_tlcInfoFree(t: *mut DdTlcInfo) -> c_void;
-    pub fn Cudd_DumpBlif(dd: *mut DdManager, n: c_int, f: *mut *mut DdNode, inames: *const *const c_char, onames: *const *const c_char, mname: *mut c_char, fp: *mut FILE, mv: c_int) -> c_int;
-    pub fn Cudd_DumpBlifBody(dd: *mut DdManager, n: c_int, f: *mut *mut DdNode, inames: *const *const c_char, onames: *const *const c_char, fp: *mut FILE, mv: c_int) -> c_int;
-    pub fn Cudd_DumpDot(dd: *mut DdManager, n: c_int, f: *mut *mut DdNode, inames: *const *const c_char, onames: *const *const c_char, fp: *mut FILE) -> c_int;
-    pub fn Cudd_DumpDaVinci(dd: *mut DdManager, n: c_int, f: *mut *mut DdNode, inames: *const *const c_char, onames: *const *const c_char, fp: *mut FILE) -> c_int;
-    pub fn Cudd_DumpDDcal(dd: *mut DdManager, n: c_int, f: *mut *mut DdNode, inames: *const *const c_char, onames: *const *const c_char, fp: *mut FILE) -> c_int;
-    pub fn Cudd_DumpFactoredForm(dd: *mut DdManager, n: c_int, f: *mut *mut DdNode, inames: *const *const c_char, onames: *const *const c_char, fp: *mut FILE) -> c_int;
-    pub fn Cudd_FactoredFormString(dd: *mut DdManager, f: *mut DdNode, inames: *const *const c_char) -> *mut c_char;
+    pub fn Cudd_DumpBlif(
+        dd: *mut DdManager,
+        n: c_int,
+        f: *mut *mut DdNode,
+        inames: *const *const c_char,
+        onames: *const *const c_char,
+        mname: *mut c_char,
+        fp: *mut FILE,
+        mv: c_int,
+    ) -> c_int;
+    pub fn Cudd_DumpBlifBody(
+        dd: *mut DdManager,
+        n: c_int,
+        f: *mut *mut DdNode,
+        inames: *const *const c_char,
+        onames: *const *const c_char,
+        fp: *mut FILE,
+        mv: c_int,
+    ) -> c_int;
+    pub fn Cudd_DumpDot(
+        dd: *mut DdManager,
+        n: c_int,
+        f: *mut *mut DdNode,
+        inames: *const *const c_char,
+        onames: *const *const c_char,
+        fp: *mut FILE,
+    ) -> c_int;
+    pub fn Cudd_DumpDaVinci(
+        dd: *mut DdManager,
+        n: c_int,
+        f: *mut *mut DdNode,
+        inames: *const *const c_char,
+        onames: *const *const c_char,
+        fp: *mut FILE,
+    ) -> c_int;
+    pub fn Cudd_DumpDDcal(
+        dd: *mut DdManager,
+        n: c_int,
+        f: *mut *mut DdNode,
+        inames: *const *const c_char,
+        onames: *const *const c_char,
+        fp: *mut FILE,
+    ) -> c_int;
+    pub fn Cudd_DumpFactoredForm(
+        dd: *mut DdManager,
+        n: c_int,
+        f: *mut *mut DdNode,
+        inames: *const *const c_char,
+        onames: *const *const c_char,
+        fp: *mut FILE,
+    ) -> c_int;
+    pub fn Cudd_FactoredFormString(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        inames: *const *const c_char,
+    ) -> *mut c_char;
     pub fn Cudd_bddConstrain(dd: *mut DdManager, f: *mut DdNode, c: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_bddRestrict(dd: *mut DdManager, f: *mut DdNode, c: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_bddNPAnd(dd: *mut DdManager, f: *mut DdNode, c: *mut DdNode) -> *mut DdNode;
@@ -418,35 +801,191 @@ extern {
     pub fn Cudd_bddLICompaction(dd: *mut DdManager, f: *mut DdNode, c: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_bddSqueeze(dd: *mut DdManager, l: *mut DdNode, u: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_bddMinimize(dd: *mut DdManager, f: *mut DdNode, c: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_SubsetCompress(dd: *mut DdManager, f: *mut DdNode, nvars: c_int, threshold: c_int) -> *mut DdNode;
-    pub fn Cudd_SupersetCompress(dd: *mut DdManager, f: *mut DdNode, nvars: c_int, threshold: c_int) -> *mut DdNode;
-    pub fn Cudd_MakeTreeNode(dd: *mut DdManager, low: c_uint, size: c_uint, ttype: c_uint) -> *mut MtrNode;
-    pub fn Cudd_addHarwell(fp: *mut FILE, dd: *mut DdManager, E: *mut *mut DdNode, x: *mut *mut *mut DdNode, y: *mut *mut *mut DdNode, xn: *mut *mut *mut DdNode, yn_: *mut *mut *mut DdNode, nx: *mut c_int, ny: *mut c_int, m: *mut c_int, n: *mut c_int, bx: c_int, sx: c_int, by: c_int, sy: c_int, pr: c_int) -> c_int;
-    pub fn Cudd_Init(numVars: c_uint, numVarsZ: c_uint, numSlots: c_uint, cacheSize: c_uint, maxMemory: c_ulong) -> *mut DdManager;
+    pub fn Cudd_SubsetCompress(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        nvars: c_int,
+        threshold: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_SupersetCompress(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        nvars: c_int,
+        threshold: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_MakeTreeNode(
+        dd: *mut DdManager,
+        low: c_uint,
+        size: c_uint,
+        ttype: c_uint,
+    ) -> *mut MtrNode;
+    pub fn Cudd_addHarwell(
+        fp: *mut FILE,
+        dd: *mut DdManager,
+        E: *mut *mut DdNode,
+        x: *mut *mut *mut DdNode,
+        y: *mut *mut *mut DdNode,
+        xn: *mut *mut *mut DdNode,
+        yn_: *mut *mut *mut DdNode,
+        nx: *mut c_int,
+        ny: *mut c_int,
+        m: *mut c_int,
+        n: *mut c_int,
+        bx: c_int,
+        sx: c_int,
+        by: c_int,
+        sy: c_int,
+        pr: c_int,
+    ) -> c_int;
+    pub fn Cudd_Init(
+        numVars: c_uint,
+        numVarsZ: c_uint,
+        numSlots: c_uint,
+        cacheSize: c_uint,
+        maxMemory: c_ulong,
+    ) -> *mut DdManager;
     pub fn Cudd_Quit(unique: *mut DdManager) -> c_void;
     pub fn Cudd_PrintLinear(table: *mut DdManager) -> c_int;
     pub fn Cudd_ReadLinear(table: *mut DdManager, x: c_int, y: c_int) -> c_int;
-    pub fn Cudd_bddLiteralSetIntersection(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addMatrixMultiply(dd: *mut DdManager, A: *mut DdNode, B: *mut DdNode, z: *mut *mut DdNode, nz: c_int) -> *mut DdNode;
-    pub fn Cudd_addTimesPlus(dd: *mut DdManager, A: *mut DdNode, B: *mut DdNode, z: *mut *mut DdNode, nz: c_int) -> *mut DdNode;
-    pub fn Cudd_addTriangle(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode, z: *mut *mut DdNode, nz: c_int) -> *mut DdNode;
-    pub fn Cudd_addOuterSum(dd: *mut DdManager, M: *mut DdNode, r: *mut DdNode, c: *mut DdNode) -> *mut DdNode;
+    pub fn Cudd_bddLiteralSetIntersection(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addMatrixMultiply(
+        dd: *mut DdManager,
+        A: *mut DdNode,
+        B: *mut DdNode,
+        z: *mut *mut DdNode,
+        nz: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_addTimesPlus(
+        dd: *mut DdManager,
+        A: *mut DdNode,
+        B: *mut DdNode,
+        z: *mut *mut DdNode,
+        nz: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_addTriangle(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        z: *mut *mut DdNode,
+        nz: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_addOuterSum(
+        dd: *mut DdManager,
+        M: *mut DdNode,
+        r: *mut DdNode,
+        c: *mut DdNode,
+    ) -> *mut DdNode;
     //M1: extern DdNode * Cudd_PrioritySelect (DdManager *dd, DdNode *R, DdNode **x, DdNode **y, DdNode **z, DdNode *Pi, int n, DdNode * (*)(DdManager *, int, DdNode **, DdNode **, DdNode **));
 
-    pub fn Cudd_Xgty(dd: *mut DdManager, N: c_int, z: *mut *mut DdNode, x: *mut *mut DdNode, y: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_Xeqy(dd: *mut DdManager, N: c_int, x: *mut *mut DdNode, y: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addXeqy(dd: *mut DdManager, N: c_int, x: *mut *mut DdNode, y: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_Dxygtdxz(dd: *mut DdManager, N: c_int, x: *mut *mut DdNode, y: *mut *mut DdNode, z: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_Dxygtdyz(dd: *mut DdManager, N: c_int, x: *mut *mut DdNode, y: *mut *mut DdNode, z: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_Inequality(dd: *mut DdManager, N: c_int, c: c_int, x: *mut *mut DdNode, y: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_Disequality(dd: *mut DdManager, N: c_int, c: c_int, x: *mut *mut DdNode, y: *mut *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_bddInterval(dd: *mut DdManager, N: c_int, x: *mut *mut DdNode, lowerB: c_uint, upperB: c_uint) -> *mut DdNode;
+    pub fn Cudd_Xgty(
+        dd: *mut DdManager,
+        N: c_int,
+        z: *mut *mut DdNode,
+        x: *mut *mut DdNode,
+        y: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_Xeqy(
+        dd: *mut DdManager,
+        N: c_int,
+        x: *mut *mut DdNode,
+        y: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_addXeqy(
+        dd: *mut DdManager,
+        N: c_int,
+        x: *mut *mut DdNode,
+        y: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_Dxygtdxz(
+        dd: *mut DdManager,
+        N: c_int,
+        x: *mut *mut DdNode,
+        y: *mut *mut DdNode,
+        z: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_Dxygtdyz(
+        dd: *mut DdManager,
+        N: c_int,
+        x: *mut *mut DdNode,
+        y: *mut *mut DdNode,
+        z: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_Inequality(
+        dd: *mut DdManager,
+        N: c_int,
+        c: c_int,
+        x: *mut *mut DdNode,
+        y: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_Disequality(
+        dd: *mut DdManager,
+        N: c_int,
+        c: c_int,
+        x: *mut *mut DdNode,
+        y: *mut *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_bddInterval(
+        dd: *mut DdManager,
+        N: c_int,
+        x: *mut *mut DdNode,
+        lowerB: c_uint,
+        upperB: c_uint,
+    ) -> *mut DdNode;
     pub fn Cudd_CProjection(dd: *mut DdManager, R: *mut DdNode, Y: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_addHamming(dd: *mut DdManager, xVars: *mut *mut DdNode, yVars: *mut *mut DdNode, nVars: c_int) -> *mut DdNode;
-    pub fn Cudd_MinHammingDist(dd: *mut DdManager, f: *mut DdNode, minterm: *mut c_int, upperBound: c_int) -> c_int;
-    pub fn Cudd_bddClosestCube(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode, distance: *mut c_int) -> *mut DdNode;
-    pub fn Cudd_addRead(fp: *mut FILE, dd: *mut DdManager, E: *mut *mut DdNode, x: *mut *mut *mut DdNode, y: *mut *mut *mut DdNode, xn: *mut *mut *mut DdNode, yn_: *mut *mut *mut DdNode, nx: *mut c_int, ny: *mut c_int, m: *mut c_int, n: *mut c_int, bx: c_int, sx: c_int, by: c_int, sy: c_int) -> c_int;
-    pub fn Cudd_bddRead(fp: *mut FILE, dd: *mut DdManager, E: *mut *mut DdNode, x: *mut *mut *mut DdNode, y: *mut *mut *mut DdNode, nx: *mut c_int, ny: *mut c_int, m: *mut c_int, n: *mut c_int, bx: c_int, sx: c_int, by: c_int, sy: c_int) -> c_int;
+    pub fn Cudd_addHamming(
+        dd: *mut DdManager,
+        xVars: *mut *mut DdNode,
+        yVars: *mut *mut DdNode,
+        nVars: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_MinHammingDist(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        minterm: *mut c_int,
+        upperBound: c_int,
+    ) -> c_int;
+    pub fn Cudd_bddClosestCube(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        distance: *mut c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_addRead(
+        fp: *mut FILE,
+        dd: *mut DdManager,
+        E: *mut *mut DdNode,
+        x: *mut *mut *mut DdNode,
+        y: *mut *mut *mut DdNode,
+        xn: *mut *mut *mut DdNode,
+        yn_: *mut *mut *mut DdNode,
+        nx: *mut c_int,
+        ny: *mut c_int,
+        m: *mut c_int,
+        n: *mut c_int,
+        bx: c_int,
+        sx: c_int,
+        by: c_int,
+        sy: c_int,
+    ) -> c_int;
+    pub fn Cudd_bddRead(
+        fp: *mut FILE,
+        dd: *mut DdManager,
+        E: *mut *mut DdNode,
+        x: *mut *mut *mut DdNode,
+        y: *mut *mut *mut DdNode,
+        nx: *mut c_int,
+        ny: *mut c_int,
+        m: *mut c_int,
+        n: *mut c_int,
+        bx: c_int,
+        sx: c_int,
+        by: c_int,
+        sy: c_int,
+    ) -> c_int;
     pub fn Cudd_Ref(n: *mut DdNode) -> c_void;
     pub fn Cudd_RecursiveDeref(table: *mut DdManager, n: *mut DdNode) -> c_void;
     pub fn Cudd_IterDerefBdd(table: *mut DdManager, n: *mut DdNode) -> c_void;
@@ -454,28 +993,112 @@ extern {
     pub fn Cudd_RecursiveDerefZdd(table: *mut DdManager, n: *mut DdNode) -> c_void;
     pub fn Cudd_Deref(node: *mut DdNode) -> c_void;
     pub fn Cudd_CheckZeroRef(manager: *mut DdManager) -> c_int;
-    pub fn Cudd_ReduceHeap(table: *mut DdManager, heuristic: Cudd_ReorderingType , minsize: c_int) -> c_int;
+    pub fn Cudd_ReduceHeap(
+        table: *mut DdManager,
+        heuristic: Cudd_ReorderingType,
+        minsize: c_int,
+    ) -> c_int;
     pub fn Cudd_ShuffleHeap(table: *mut DdManager, permutation: *mut c_int) -> c_int;
     pub fn Cudd_Eval(dd: *mut DdManager, f: *mut DdNode, inputs: *mut c_int) -> *mut DdNode;
-    pub fn Cudd_ShortestPath(manager: *mut DdManager, f: *mut DdNode, weight: *mut c_int, support: *mut c_int, length: *mut c_int) -> *mut DdNode;
-    pub fn Cudd_LargestCube(manager: *mut DdManager, f: *mut DdNode, length: *mut c_int) -> *mut DdNode;
-    pub fn Cudd_ShortestLength(manager: *mut DdManager, f: *mut DdNode, weight: *mut c_int) -> c_int;
+    pub fn Cudd_ShortestPath(
+        manager: *mut DdManager,
+        f: *mut DdNode,
+        weight: *mut c_int,
+        support: *mut c_int,
+        length: *mut c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_LargestCube(
+        manager: *mut DdManager,
+        f: *mut DdNode,
+        length: *mut c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_ShortestLength(
+        manager: *mut DdManager,
+        f: *mut DdNode,
+        weight: *mut c_int,
+    ) -> c_int;
     pub fn Cudd_Decreasing(dd: *mut DdManager, f: *mut DdNode, i: c_int) -> *mut DdNode;
     pub fn Cudd_Increasing(dd: *mut DdManager, f: *mut DdNode, i: c_int) -> *mut DdNode;
-    pub fn Cudd_EquivDC(dd: *mut DdManager, F: *mut DdNode, G: *mut DdNode, D: *mut DdNode) -> c_int;
-    pub fn Cudd_bddLeqUnless(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode, D: *mut DdNode) -> c_int;
-    pub fn Cudd_EqualSupNorm(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode, tolerance: CUDD_VALUE_TYPE , pr: c_int) -> c_int;
+    pub fn Cudd_EquivDC(
+        dd: *mut DdManager,
+        F: *mut DdNode,
+        G: *mut DdNode,
+        D: *mut DdNode,
+    ) -> c_int;
+    pub fn Cudd_bddLeqUnless(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        D: *mut DdNode,
+    ) -> c_int;
+    pub fn Cudd_EqualSupNorm(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        tolerance: CUDD_VALUE_TYPE,
+        pr: c_int,
+    ) -> c_int;
     pub fn Cudd_bddMakePrime(dd: *mut DdManager, cube: *mut DdNode, f: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_bddMaximallyExpand(dd: *mut DdManager, lb: *mut DdNode, ub: *mut DdNode, f: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_bddLargestPrimeUnate(dd: *mut DdManager, f: *mut DdNode, phaseBdd: *mut DdNode) -> *mut DdNode;
+    pub fn Cudd_bddMaximallyExpand(
+        dd: *mut DdManager,
+        lb: *mut DdNode,
+        ub: *mut DdNode,
+        f: *mut DdNode,
+    ) -> *mut DdNode;
+    pub fn Cudd_bddLargestPrimeUnate(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        phaseBdd: *mut DdNode,
+    ) -> *mut DdNode;
     pub fn Cudd_CofMinterm(dd: *mut DdManager, node: *mut DdNode) -> *mut c_double;
-    pub fn Cudd_SolveEqn(bdd: *mut DdManager, F: *mut DdNode, Y: *mut DdNode, G: *mut *mut DdNode, yIndex: *mut *mut c_int, n: c_int) -> *mut DdNode;
-    pub fn Cudd_VerifySol(bdd: *mut DdManager, F: *mut DdNode, G: *mut *mut DdNode, yIndex: *mut c_int, n: c_int) -> *mut DdNode;
-    pub fn Cudd_SplitSet(manager: *mut DdManager, S: *mut DdNode, xVars: *mut *mut DdNode, n: c_int, m: c_double) -> *mut DdNode;
-    pub fn Cudd_SubsetHeavyBranch(dd: *mut DdManager, f: *mut DdNode, numVars: c_int, threshold: c_int) -> *mut DdNode;
-    pub fn Cudd_SupersetHeavyBranch(dd: *mut DdManager, f: *mut DdNode, numVars: c_int, threshold: c_int) -> *mut DdNode;
-    pub fn Cudd_SubsetShortPaths(dd: *mut DdManager, f: *mut DdNode, numVars: c_int, threshold: c_int, hardlimit: c_int) -> *mut DdNode;
-    pub fn Cudd_SupersetShortPaths(dd: *mut DdManager, f: *mut DdNode, numVars: c_int, threshold: c_int, hardlimit: c_int) -> *mut DdNode;
+    pub fn Cudd_SolveEqn(
+        bdd: *mut DdManager,
+        F: *mut DdNode,
+        Y: *mut DdNode,
+        G: *mut *mut DdNode,
+        yIndex: *mut *mut c_int,
+        n: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_VerifySol(
+        bdd: *mut DdManager,
+        F: *mut DdNode,
+        G: *mut *mut DdNode,
+        yIndex: *mut c_int,
+        n: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_SplitSet(
+        manager: *mut DdManager,
+        S: *mut DdNode,
+        xVars: *mut *mut DdNode,
+        n: c_int,
+        m: c_double,
+    ) -> *mut DdNode;
+    pub fn Cudd_SubsetHeavyBranch(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        numVars: c_int,
+        threshold: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_SupersetHeavyBranch(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        numVars: c_int,
+        threshold: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_SubsetShortPaths(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        numVars: c_int,
+        threshold: c_int,
+        hardlimit: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_SupersetShortPaths(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        numVars: c_int,
+        threshold: c_int,
+        hardlimit: c_int,
+    ) -> *mut DdNode;
     pub fn Cudd_SymmProfile(table: *mut DdManager, lower: c_int, upper: c_int) -> c_void;
     pub fn Cudd_Prime(p: c_uint) -> c_uint;
     pub fn Cudd_Reserve(manager: *mut DdManager, amount: c_int) -> c_int;
@@ -483,36 +1106,105 @@ extern {
     pub fn Cudd_bddPrintCover(dd: *mut DdManager, l: *mut DdNode, u: *mut DdNode) -> c_int;
     pub fn Cudd_PrintDebug(dd: *mut DdManager, f: *mut DdNode, n: c_int, pr: c_int) -> c_int;
     pub fn Cudd_DagSize(node: *mut DdNode) -> c_int;
-    pub fn Cudd_EstimateCofactor(dd: *mut DdManager, node: *mut DdNode, i: c_int, phase: c_int) -> c_int;
+    pub fn Cudd_EstimateCofactor(
+        dd: *mut DdManager,
+        node: *mut DdNode,
+        i: c_int,
+        phase: c_int,
+    ) -> c_int;
     pub fn Cudd_EstimateCofactorSimple(node: *mut DdNode, i: c_int) -> c_int;
     pub fn Cudd_SharingSize(nodeArray: *mut *mut DdNode, n: c_int) -> c_int;
     pub fn Cudd_CountMinterm(manager: *mut DdManager, node: *mut DdNode, nvars: c_int) -> c_double;
     //pub fn Cudd_EpdCountMinterm(manager: *mut DdManager, node: *mut DdNode, nvars: c_int, epd: *mut c_EpDouble) -> c_int;
     pub fn Cudd_CountPath(node: *mut DdNode) -> c_double;
     pub fn Cudd_CountPathsToNonZero(node: *mut DdNode) -> c_double;
-    pub fn Cudd_SupportIndices(dd: *mut DdManager, f: *mut DdNode, indices: *mut *mut c_int) -> c_int;
+    pub fn Cudd_SupportIndices(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        indices: *mut *mut c_int,
+    ) -> c_int;
     pub fn Cudd_Support(dd: *mut DdManager, f: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_SupportIndex(dd: *mut DdManager, f: *mut DdNode) -> *mut c_int;
     pub fn Cudd_SupportSize(dd: *mut DdManager, f: *mut DdNode) -> c_int;
-    pub fn Cudd_VectorSupportIndices(dd: *mut DdManager, F: *mut *mut DdNode, n: c_int, indices: *mut *mut c_int) -> c_int;
+    pub fn Cudd_VectorSupportIndices(
+        dd: *mut DdManager,
+        F: *mut *mut DdNode,
+        n: c_int,
+        indices: *mut *mut c_int,
+    ) -> c_int;
     pub fn Cudd_VectorSupport(dd: *mut DdManager, F: *mut *mut DdNode, n: c_int) -> *mut DdNode;
-    pub fn Cudd_VectorSupportIndex(dd: *mut DdManager, F: *mut *mut DdNode, n: c_int) -> *mut c_int;
+    pub fn Cudd_VectorSupportIndex(dd: *mut DdManager, F: *mut *mut DdNode, n: c_int)
+        -> *mut c_int;
     pub fn Cudd_VectorSupportSize(dd: *mut DdManager, F: *mut *mut DdNode, n: c_int) -> c_int;
-    pub fn Cudd_ClassifySupport(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode, common: *mut *mut DdNode, onlyF: *mut *mut DdNode, onlyG: *mut *mut DdNode) -> c_int;
+    pub fn Cudd_ClassifySupport(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        common: *mut *mut DdNode,
+        onlyF: *mut *mut DdNode,
+        onlyG: *mut *mut DdNode,
+    ) -> c_int;
     pub fn Cudd_CountLeaves(node: *mut DdNode) -> c_int;
-    pub fn Cudd_bddPickOneCube(ddm: *mut DdManager, node: *mut DdNode, string: *mut c_char) -> c_int;
-    pub fn Cudd_bddPickOneMinterm(dd: *mut DdManager, f: *mut DdNode, vars: *mut *mut DdNode, n: c_int) -> *mut DdNode;
-    pub fn Cudd_bddPickArbitraryMinterms(dd: *mut DdManager, f: *mut DdNode, vars: *mut *mut DdNode, n: c_int, k: c_int) -> *mut *mut DdNode;
-    pub fn Cudd_SubsetWithMaskVars(dd: *mut DdManager, f: *mut DdNode, vars: *mut *mut DdNode, nvars: c_int, maskVars: *mut *mut DdNode, mvars: c_int) -> *mut DdNode;
-    pub fn Cudd_FirstCube(dd: *mut DdManager, f: *mut DdNode, cube: *mut *mut c_int, value: *mut CUDD_VALUE_TYPE) -> *mut DdGen;
-    pub fn Cudd_NextCube(gen: *mut DdGen, cube: *mut *mut c_int, value: *mut CUDD_VALUE_TYPE) -> c_int;
-    pub fn Cudd_FirstPrime(dd: *mut DdManager, l: *mut DdNode, u: *mut DdNode, cube: *mut *mut c_int) -> *mut DdGen;
+    pub fn Cudd_bddPickOneCube(
+        ddm: *mut DdManager,
+        node: *mut DdNode,
+        string: *mut c_char,
+    ) -> c_int;
+    pub fn Cudd_bddPickOneMinterm(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        vars: *mut *mut DdNode,
+        n: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_bddPickArbitraryMinterms(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        vars: *mut *mut DdNode,
+        n: c_int,
+        k: c_int,
+    ) -> *mut *mut DdNode;
+    pub fn Cudd_SubsetWithMaskVars(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        vars: *mut *mut DdNode,
+        nvars: c_int,
+        maskVars: *mut *mut DdNode,
+        mvars: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_FirstCube(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        cube: *mut *mut c_int,
+        value: *mut CUDD_VALUE_TYPE,
+    ) -> *mut DdGen;
+    pub fn Cudd_NextCube(
+        gen: *mut DdGen,
+        cube: *mut *mut c_int,
+        value: *mut CUDD_VALUE_TYPE,
+    ) -> c_int;
+    pub fn Cudd_FirstPrime(
+        dd: *mut DdManager,
+        l: *mut DdNode,
+        u: *mut DdNode,
+        cube: *mut *mut c_int,
+    ) -> *mut DdGen;
     pub fn Cudd_NextPrime(gen: *mut DdGen, cube: *mut *mut c_int) -> c_int;
-    pub fn Cudd_bddComputeCube(dd: *mut DdManager, vars: *mut *mut DdNode, phase: *mut c_int, n: c_int) -> *mut DdNode;
-    pub fn Cudd_addComputeCube(dd: *mut DdManager, vars: *mut *mut DdNode, phase: *mut c_int, n: c_int) -> *mut DdNode;
+    pub fn Cudd_bddComputeCube(
+        dd: *mut DdManager,
+        vars: *mut *mut DdNode,
+        phase: *mut c_int,
+        n: c_int,
+    ) -> *mut DdNode;
+    pub fn Cudd_addComputeCube(
+        dd: *mut DdManager,
+        vars: *mut *mut DdNode,
+        phase: *mut c_int,
+        n: c_int,
+    ) -> *mut DdNode;
     pub fn Cudd_CubeArrayToBdd(dd: *mut DdManager, array: *mut c_int) -> *mut DdNode;
     pub fn Cudd_BddToCubeArray(dd: *mut DdManager, cube: *mut DdNode, array: *mut c_int) -> c_int;
-    pub fn Cudd_FirstNode(dd: *mut DdManager, f: *mut DdNode, node: *mut *mut DdNode) -> *mut DdGen;
+    pub fn Cudd_FirstNode(dd: *mut DdManager, f: *mut DdNode, node: *mut *mut DdNode)
+        -> *mut DdGen;
     pub fn Cudd_NextNode(gen: *mut DdGen, node: *mut *mut DdNode) -> c_int;
     pub fn Cudd_GenFree(gen: *mut DdGen) -> c_int;
     pub fn Cudd_IsGenEmpty(gen: *mut DdGen) -> c_int;
@@ -532,8 +1224,18 @@ extern {
     pub fn Cudd_zddWeakDivF(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_zddDivideF(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_zddComplement(dd: *mut DdManager, node: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_MakeZddTreeNode(dd: *mut DdManager, low: c_uint, size: c_uint, ttype: c_uint) -> *mut MtrNode;
-    pub fn Cudd_zddIsop(dd: *mut DdManager, L: *mut DdNode, U: *mut DdNode, zdd_I: *mut *mut DdNode) -> *mut DdNode;
+    pub fn Cudd_MakeZddTreeNode(
+        dd: *mut DdManager,
+        low: c_uint,
+        size: c_uint,
+        ttype: c_uint,
+    ) -> *mut MtrNode;
+    pub fn Cudd_zddIsop(
+        dd: *mut DdManager,
+        L: *mut DdNode,
+        U: *mut DdNode,
+        zdd_I: *mut *mut DdNode,
+    ) -> *mut DdNode;
     pub fn Cudd_bddIsop(dd: *mut DdManager, L: *mut DdNode, U: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_MakeBddFromZddCover(dd: *mut DdManager, node: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_zddDagSize(p_node: *mut DdNode) -> c_int;
@@ -541,9 +1243,18 @@ extern {
     pub fn Cudd_zddPrintSubtable(table: *mut DdManager) -> c_void;
     pub fn Cudd_zddPortFromBdd(dd: *mut DdManager, B: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_zddPortToBdd(dd: *mut DdManager, f: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_zddReduceHeap(table: *mut DdManager, heuristic: Cudd_ReorderingType , minsize: c_int) -> c_int;
+    pub fn Cudd_zddReduceHeap(
+        table: *mut DdManager,
+        heuristic: Cudd_ReorderingType,
+        minsize: c_int,
+    ) -> c_int;
     pub fn Cudd_zddShuffleHeap(table: *mut DdManager, permutation: *mut c_int) -> c_int;
-    pub fn Cudd_zddIte(dd: *mut DdManager, f: *mut DdNode, g: *mut DdNode, h: *mut DdNode) -> *mut DdNode;
+    pub fn Cudd_zddIte(
+        dd: *mut DdManager,
+        f: *mut DdNode,
+        g: *mut DdNode,
+        h: *mut DdNode,
+    ) -> *mut DdNode;
     pub fn Cudd_zddUnion(dd: *mut DdManager, P: *mut DdNode, Q: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_zddIntersect(dd: *mut DdManager, P: *mut DdNode, Q: *mut DdNode) -> *mut DdNode;
     pub fn Cudd_zddDiff(dd: *mut DdManager, P: *mut DdNode, Q: *mut DdNode) -> *mut DdNode;
@@ -555,11 +1266,26 @@ extern {
     pub fn Cudd_zddPrintMinterm(zdd: *mut DdManager, node: *mut DdNode) -> c_int;
     pub fn Cudd_zddPrintCover(zdd: *mut DdManager, node: *mut DdNode) -> c_int;
     pub fn Cudd_zddPrintDebug(zdd: *mut DdManager, f: *mut DdNode, n: c_int, pr: c_int) -> c_int;
-    pub fn Cudd_zddFirstPath(zdd: *mut DdManager, f: *mut DdNode, path: *mut *mut c_int) -> *mut DdGen;
+    pub fn Cudd_zddFirstPath(
+        zdd: *mut DdManager,
+        f: *mut DdNode,
+        path: *mut *mut c_int,
+    ) -> *mut DdGen;
     pub fn Cudd_zddNextPath(gen: *mut DdGen, path: *mut *mut c_int) -> c_int;
-    pub fn Cudd_zddCoverPathToString(zdd: *mut DdManager, path: *mut c_int, str: *mut c_char) -> *mut c_char;
+    pub fn Cudd_zddCoverPathToString(
+        zdd: *mut DdManager,
+        path: *mut c_int,
+        str: *mut c_char,
+    ) -> *mut c_char;
     pub fn Cudd_zddSupport(dd: *mut DdManager, f: *mut DdNode) -> *mut DdNode;
-    pub fn Cudd_zddDumpDot(dd: *mut DdManager, n: c_int, f: *mut *mut DdNode, inames: *const *const c_char, onames: *const *const c_char, fp: *mut FILE) -> c_int;
+    pub fn Cudd_zddDumpDot(
+        dd: *mut DdManager,
+        n: c_int,
+        f: *mut *mut DdNode,
+        inames: *const *const c_char,
+        onames: *const *const c_char,
+        fp: *mut FILE,
+    ) -> c_int;
     pub fn Cudd_bddSetPiVar(dd: *mut DdManager, index: c_int) -> c_int;
     pub fn Cudd_bddSetPsVar(dd: *mut DdManager, index: c_int) -> c_int;
     pub fn Cudd_bddSetNsVar(dd: *mut DdManager, index: c_int) -> c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub enum Cudd_VariableType {
 pub type DdHalfWord = libc::uint16_t;
 
 #[cfg(all(target_pointer_width = "64"))]
-pub type DdHalfWord = libc::uint32_t;
+pub type DdHalfWord = u32;
 
 #[repr(C)]
 pub struct DdNode

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(non_camel_case_types)] // Allow non-idiomatic names in the whole crate.
 extern crate libc;
 
 use libc::{c_void,c_uint,c_long,c_ulong,c_int,c_char,c_double,FILE};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,10 @@
-#![allow(non_camel_case_types)] // Allow non-idiomatic names in the whole crate.
+// Allow non-idiomatic names in the whole crate.
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
 extern crate libc;
+
+#[cfg(test)]
+mod test;
 
 use libc::{c_char, c_double, c_int, c_long, c_uint, c_ulong, c_void, FILE};
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,29 @@
+use Cudd_Quit;
+use {Cudd_Init, CUDD_CACHE_SLOTS};
+use {Cudd_Ref, Cudd_bddAnd};
+use {Cudd_bddIthVar, CUDD_UNIQUE_SLOTS};
+use {Cudd_bddNand, Cudd_bddNor};
+
+#[test]
+pub fn basic_functionality_test() {
+    unsafe {
+        let cudd = Cudd_Init(0, 0, CUDD_UNIQUE_SLOTS, CUDD_CACHE_SLOTS, 0);
+        // Check that the basic identity (a & b) <=> !(!a | !b) holds.
+        let a = Cudd_bddIthVar(cudd, 1);
+        let b = Cudd_bddIthVar(cudd, 2);
+        // There is a Cudd_Not macro, but that is not available through bindings.
+        let not_a = Cudd_bddNand(cudd, a, a);
+        let not_b = Cudd_bddNand(cudd, b, b);
+        Cudd_Ref(not_a);
+        Cudd_Ref(not_b);
+
+        let a_and_b = Cudd_bddAnd(cudd, a, b);
+        Cudd_Ref(a_and_b);
+
+        let not_a_or_b = Cudd_bddNor(cudd, not_a, not_b);
+        Cudd_Ref(not_a_or_b);
+
+        assert_eq!(a_and_b, not_a_or_b);
+        Cudd_Quit(cudd);
+    }
+}


### PR DESCRIPTION
This pull request aims to make the `cudd-sys` crate usable again.

The changes include:
 - Migrate to a new url for source download (unofficial [Github mirror](https://github.com/ivmai/cudd)), since the old url is dead.
 - Fixes warnings and migrations to latest Rust syntax/idioms.
 - Replaces Travis CI with a Github Actions workflow.
 - Add a simple functionality test to verify compilation/linking did not break.
 - Add a simple readme file which links to the CUDD manual and API docs.
 
I'd be very happy if this could be merged and published to `crates.io` so that we can use `cudd-sys` in our projects as a dependency instead of linking to random github repositories or creating a new crate :) Alternatively, if you do not plan on supporting `cudd-sys` any further (since it is last updated 6 years ago), I'd be willing to participate as a maintainer (I am also planning to add support for CUDD 3.0.0).