### PR TITLE
upgrade to edition 2024, rust 1.90, new cudd repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,9 @@ on: [push]
 env:
   # A fixed version used for testing, so that the builds don't
   # spontaneously break after a few years.
-  RUST_VERSION: "1.53.0"
+  RUST_VERSION: "1.90.0"
+  CARGO_TERM_COLOR: always
+
 jobs:
   # Checks syntax formatting.
   fmt:
@@ -12,17 +14,13 @@ jobs:
     env:
       RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.RUST_VERSION }}
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - uses: actions/checkout@v4
+      - name: Install rust version
+        run: rustup install ${RUST_VERSION}
+      - name: Add rustfmt
+        run: rustup +${RUST_VERSION} component add rustfmt
+      - name: Check formatting
+        run: cargo +${RUST_VERSION} fmt -- --check
 
   # Run basic code validity check.
   check:
@@ -32,15 +30,11 @@ jobs:
     env:
       RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.RUST_VERSION }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - uses: actions/checkout@v4
+      - name: Install rust version
+        run: rustup install ${RUST_VERSION}
+      - name: check
+        run: cargo +${RUST_VERSION} check
 
   # Run tests.
   test:
@@ -50,15 +44,11 @@ jobs:
     env:
       RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.RUST_VERSION }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - uses: actions/checkout@v4
+      - name: Install rust version
+        run: rustup install ${RUST_VERSION}
+      - name: check
+        run: cargo +${RUST_VERSION} test
 
   # Run tests on macOS.
   test-macos:
@@ -68,15 +58,11 @@ jobs:
     env:
       RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.RUST_VERSION }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - uses: actions/checkout@v4
+      - name: Install rust version
+        run: rustup install ${RUST_VERSION}
+      - name: check
+        run: cargo +${RUST_VERSION} test
 
   # Checks code style.
   clippy:
@@ -86,13 +72,10 @@ jobs:
     env:
       RUSTFLAGS: "-D warnings"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.RUST_VERSION }}
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
+      - uses: actions/checkout@v4
+      - name: Install rust version
+        run: rustup install ${RUST_VERSION}
+      - name: Add clippy
+        run: rustup +${RUST_VERSION} component add clippy
+      - name: check
+        run: cargo +${RUST_VERSION} clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cudd-sys"
 version = "1.0.0"
+edition = "2024"
 authors = ["Philip Lewis <pcl@pclewis.com>"]
 build = "build.rs"
 description = "Bindings for CU Decision Diagram library (CUDD)"
@@ -11,7 +12,7 @@ license = "CC0-1.0"
 libc = "0.2"
 
 [build-dependencies]
-autotools = "0.2.3"
+autotools = "0.2.7"
 
 [features]
 default = ["build_cudd"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This crate provides unsafe Rust bindings for the University of Colorado decision diagram
 package (CUDD), including the DDDMP serialisation library. It uses version `3.0.0` of CUDD
-available from the unofficial [Github mirror](https://github.com/ivmai/cudd) and compiles on
+available from the unofficial [Github mirror](https://github.com/cuddorg/cudd) and compiles on
 Linux and MacOS (you should be also able to build CUDD on Windows using cygwin, but the project
 is not set-up to do it automatically).
 
@@ -33,4 +33,4 @@ a function that isn't exported yet, let us know in the issues.
 reproduced using a semi-automated method with a manual validation step (bunch of regexes
 that a human makes sure didn't break anything ;)). As such, it is possible that there
 are some minor problems that need to be sorted out. Please file an issue if you see any
-unexpected behaviour or segfaults.
+unexpected behavior or segfaults.

--- a/src/dddmp.rs
+++ b/src/dddmp.rs
@@ -1,5 +1,5 @@
-use libc::{c_char, c_int, FILE};
-use {DdManager, DdNode};
+use crate::{DdManager, DdNode};
+use libc::{FILE, c_char, c_int};
 
 /// Version of DDDMP format.
 pub const DDDMP_VERSION: &str = "DDDMP-2.0";
@@ -65,7 +65,7 @@ pub enum Dddmp_RootMatchType {
     DDDMP_ROOT_MATCHLIST,
 }
 
-extern "C" {
+unsafe extern "C" {
     pub fn Dddmp_Text2Bin(filein: *mut c_char, fileout: *mut c_char) -> c_int;
     pub fn Dddmp_Bin2Text(filein: *mut c_char, fileout: *mut c_char) -> c_int;
     pub fn Dddmp_cuddBddDisplayBinary(fileIn: *mut c_char, fileOut: *mut c_char) -> c_int;

--- a/src/epd.rs
+++ b/src/epd.rs
@@ -1,8 +1,8 @@
+use crate::EpDouble;
 use libc::{c_int, c_void};
 use std::os::raw::{c_char, c_double};
-use EpDouble;
 
-extern "C" {
+unsafe extern "C" {
     pub fn EpdAlloc() -> *mut EpDouble;
     pub fn EpdCmp(key1: *const c_void, key2: *const c_void) -> c_int;
     pub fn EpdFree(epd: *mut EpDouble) -> c_void;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! is not set-up to do it automatically).
 //!
 //! > On Linux and macOS, you should ideally have `autoconf`, `automake` and `libtool` installed
-//!  to build CUDD. And of course, some C/C++ compiler (`clang`, `gcc`, etc.).
+//! > to build CUDD. And of course, some C/C++ compiler (`clang`, `gcc`, etc.).
 //!
 //! In the root module, you will find declarations of the C structs and types used
 //! throughout CUDD. The main API of the CUDD package is then exported in `::cudd`. However,

--- a/src/mtr.rs
+++ b/src/mtr.rs
@@ -1,5 +1,5 @@
-use libc::{c_int, c_uint, c_void, FILE};
-use MtrNode;
+use crate::MtrNode;
+use libc::{FILE, c_int, c_uint, c_void};
 
 /// Default flag value in `Mtr_MakeGroup`.
 pub const MTR_DEFAULT: c_uint = 0;
@@ -12,7 +12,7 @@ pub const MTR_FIXED: c_uint = 4;
 /// See `Mtr_MakeGroup`.
 pub const MTR_NEWNODE: c_uint = 8;
 
-extern "C" {
+unsafe extern "C" {
     pub fn Mtr_AllocNode() -> *mut MtrNode;
     pub fn Mtr_DeallocNode(node: *mut MtrNode) -> c_void;
     pub fn Mtr_InitTree() -> *mut MtrNode;

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,4 @@
-use cudd::*;
+use crate::cudd::*;
 use libc::{c_int, c_void};
 use std::ptr::null_mut;
 


### PR DESCRIPTION
This commit upgrades the crate to edition 2024 and rust version 1.90 and switches to the cudd repo of the newly formed cudd [organisation](https://github.com/cuddorg).

The upgrade includes
- switching to the new import syntax
- replacing or escaping the 'gen' variable names where necessary
- wraping 'extern' declartion in unsafe blocks
- fixing the clippy complaints
- upgrading github action workflow

Additionally, the build process now uses sha256 sums instead of md5 sums.



