### PR TITLE
update download URL to point to renamed release

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 const PACKAGE_URL: &str =
-    "https://github.com/cuddorg/cudd/releases/download/cudd-3.0.0/cudd-3.0.0.tar.gz";
+    "https://github.com/cuddorg/cudd/releases/download/3.0.0/cudd-3.0.0.tar.gz";
 const PACKAGE_SHA256: &str = "5fe145041c594689e6e7cf4cd623d5f2b7c36261708be8c9a72aed72cf67acce";
 
 #[derive(Debug)]


### PR DESCRIPTION
This commit updates the URL to point to the "3.0.0" release (previously "cudd-3.0.0).

On an unrelated note: It looks like they are preparing for a 4.0.0 release (there are already prereleases). Maybe it is now a good time to ask whether they are interested in a transfer of ownership ? 
The new release will use CMake, so there will be some changes required. I don't mind contributing them here, but we already talked about it in the last PR https://github.com/pclewis/cudd-sys/pull/4
